### PR TITLE
build: add windows build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
       - amd64
       - arm64
     goarm:
-      - 7
+      - '7'
     ignore:
       - goos: windows
         goarch: arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,11 +8,15 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64
     goarm:
       - 7
+    ignore:
+      - goos: windows
+        goarch: arm64
     main: ./cmd/nssh/main.go
     binary: nssh
     flags:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ At this moment, the client is only tested on following platforms. It can be buil
 
 - DebianGNU/Linux 11 (bullseye) aarch64
 - macOS 13.4.1 (Ventura) arm64
+- Windows 10 + `cmd.exe` amd64
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Napter is an on-demand networking service for devices using Soracom Air for Cell
 
 ## Tested Platform
 
-At this moment, the client is only tested on folloing platforms. It can be built for other Linux distributions and Windows but might not work due to `x/crypto/ssh.readVersion` hang, etc. PR's welcome.
+At this moment, the client is only tested on following platforms. It can be built for other Linux distributions and Windows but might not work due to `x/crypto/ssh.readVersion` hang, etc. PR's welcome.
 
 - DebianGNU/Linux 11 (bullseye) aarch64
 - macOS 13.4.1 (Ventura) arm64
@@ -169,7 +169,7 @@ MIT. See [LICENSE](LICENSE) for details.
 This program will send requests to following services:
 
 - https://checkip.amazonaws.com/, to determine your global IP address.
-- https://g.api.soracom.io (Global coverage) or https://api.soracom.io (Japan coverage), to use SORACOM services
+- https://g.api.soracom.io (Global coverage) or https://api.soracom.io (Japan coverage), to use SORACOM services.
 
 Other than that, the program does not send user action/data to any server. Please consult each provider's privacy notices.
 

--- a/client.go
+++ b/client.go
@@ -278,7 +278,9 @@ func (c *SoracomClient) Connect(login, identity string, portMapping *PortMapping
 
 	w, h, err := terminal.GetSize(fd)
 	if err != nil {
-		return err
+		fmt.Println("failed to get terminal size, using default values", err)
+		w = 80
+		h = 24
 	}
 
 	err = session.RequestPty("xterm", h, w, ssh.TerminalModes{

--- a/client.go
+++ b/client.go
@@ -338,7 +338,7 @@ func (c *SoracomClient) Connect(login, identity string, portMapping *PortMapping
 
 func readPassword(prompt string) (string, error) {
 	fmt.Print(prompt)
-	password, err := terminal.ReadPassword(syscall.Stdin)
+	password, err := terminal.ReadPassword(int(syscall.Stdin))
 	return string(password), err
 }
 


### PR DESCRIPTION
- feat: use default width/height on error
- fix: revert 2eb22046ae18df8bfa8f8cb469dfab566b7ca9b8
- docs: typo and punctuation
- build: add windows build
- chore: YAML schema conformance
